### PR TITLE
Updated requirements.txt

### DIFF
--- a/documentation/sphinx/requirements.txt
+++ b/documentation/sphinx/requirements.txt
@@ -1,5 +1,5 @@
 --index-url https://pypi.python.org/simple
-sphinx==1.5.6
+sphinx==1.6.7
 sphinx-bootstrap-theme==0.4.8
 docutils==0.16
 Jinja2==3.0.3


### PR DESCRIPTION
1. We can see an error "The alabaster extension used by this project needs at least Sphinx v1.6; it therefore cannot be built with this version." https://github.com/owtech/foundationdb/actions/runs/3958476939/jobs/6795913802#step:6:1993 
2. We've checked which version of alabaster has been installed "Successfully installed Jinja2-3.0.3 MarkupSafe-2.0.1 Pygments-14.0 alabaster-0.7.13" https://github.com/owtech/foundationdb/actions/runs/3958476939/jobs/6795913802#step:6:1959 
3. Checked that version of alabaster 0.7.13 is latest : https://github.com/bitprophet/alabaster 
4. After that we had seen documentation https://alabaster.readthedocs.io/en/latest/index.html?highlight=Sphinx#what-is-alabaster and saw "It requires Python 3.8 or newer and Sphinx 1.6 or newer." 
5. Checked repo alabaster and saw new commit bitprophet/alabaster@0bd2b35 Comment is containing text "Require Sphinx 1.6 or newer"